### PR TITLE
Bugfix - shake detection is now not triggered if global_read_aloud is off

### DIFF
--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/NotificationListener.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/NotificationListener.java
@@ -3,23 +3,38 @@ package com.mocha17.slayer.notification;
 import android.app.Notification;
 import android.app.Service;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.service.notification.NotificationListenerService;
 import android.service.notification.StatusBarNotification;
 import android.text.TextUtils;
 
+import com.mocha17.slayer.R;
 import com.mocha17.slayer.SlayerApp;
 import com.mocha17.slayer.communication.WearDataSender;
+import com.mocha17.slayer.utils.Logger;
 
 /**
  * Created by Chaitanya on 5/2/15.
  */
 public class NotificationListener extends NotificationListenerService {
+    SharedPreferences defaultSharedPreferences;
+
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         super.onStartCommand(intent, flags, startId);
         //TODO Add foreground notification based on user preference
-        return Service.START_NOT_STICKY;
+
+        defaultSharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+        if (defaultSharedPreferences.getBoolean(
+                getString(R.string.pref_key_global_read_aloud), false)) {
+            return Service.START_STICKY;
+        } else {
+            Logger.d(this, "onStartCommand, global_read_aloud is off, stopping self");
+            stopSelf();
+            return START_NOT_STICKY;
+        }
     }
 
     @Override
@@ -27,8 +42,15 @@ public class NotificationListener extends NotificationListenerService {
         /*TODO
         replace this with a Queue. We are recording the last notification
         posted using the App instance */
-        SlayerApp.getInstance().setNotificationString(getNotifString(statusBarNotification));
-        WearDataSender.startShakeDetection(this);
+        if (defaultSharedPreferences.getBoolean(
+                getString(R.string.pref_key_global_read_aloud), false)) {
+            Logger.d(this, "onNotificationPosted initiating shake detection");
+            SlayerApp.getInstance().setNotificationString(getNotifString(statusBarNotification));
+            WearDataSender.startShakeDetection(this);
+        } else {
+            Logger.d(this, "onNotificationPosted global_read_aloud off," +
+                    "shake detection wasn't initiated");
+        }
     }
 
     @Override


### PR DESCRIPTION
We need more checks before starting shake detection anyways. As the flow has started working reliably, this change has become very necessary. ;)