### PR TITLE
Issue #25 Setting to use maximum volume to read notifications

### DIFF
--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/settings/SettingsFragment.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/settings/SettingsFragment.java
@@ -25,7 +25,8 @@ public class SettingsFragment extends PreferenceFragment implements
     private SharedPreferences defaultSharedPreferences;
     private SharedPreferences.Editor editor;
 
-    private SwitchPreference prefGlobalReadAloud, prefPersistentNotification, prefAndroidWear;
+    private SwitchPreference prefGlobalReadAloud, prefMaxVolume,
+            prefPersistentNotification,prefAndroidWear;
     private Preference prefApps;
 
     public static SettingsFragment newInstance() {
@@ -77,6 +78,14 @@ public class SettingsFragment extends PreferenceFragment implements
             prefApps.setOnPreferenceClickListener(this);
         }
 
+        //Volume
+        key = getString(R.string.pref_key_max_volume);
+        prefMaxVolume = (SwitchPreference)findPreference(key);
+        if (prefMaxVolume != null) {
+            prefMaxVolume.setOnPreferenceChangeListener(this);
+            prefMaxVolume.setChecked(defaultSharedPreferences.getBoolean(key, false));
+        }
+
         //Persistent notification
         key = getString(R.string.pref_key_persistent_notification);
         prefPersistentNotification = (SwitchPreference)findPreference(key);
@@ -108,6 +117,10 @@ public class SettingsFragment extends PreferenceFragment implements
                 prefApps.setEnabled(true);
                 setPrefAppsSummary();
 
+                prefMaxVolume.setEnabled(true);
+                prefMaxVolume.setChecked(defaultSharedPreferences.getBoolean(
+                        getString(R.string.pref_key_max_volume), true));
+
                 prefAndroidWear.setEnabled(true);
                 prefAndroidWear.setChecked(defaultSharedPreferences.getBoolean(
                         getString(R.string.pref_key_android_wear), true));
@@ -115,6 +128,7 @@ public class SettingsFragment extends PreferenceFragment implements
             } else {
                 prefPersistentNotification.setEnabled(false);
                 prefApps.setEnabled(false);
+                prefMaxVolume.setEnabled(false);
                 prefAndroidWear.setEnabled(false);
             }
         }
@@ -162,6 +176,12 @@ public class SettingsFragment extends PreferenceFragment implements
         if (getString(R.string.pref_key_persistent_notification).equals(key)) {
             boolean value = (boolean) newValue;
             prefPersistentNotification.setChecked(value);
+            editor.putBoolean(key, value).apply();
+            return true;
+        }
+        if (getString(R.string.pref_key_max_volume).equals(key)) {
+            boolean value = (boolean) newValue;
+            prefMaxVolume.setChecked(value);
             editor.putBoolean(key, value).apply();
             return true;
         }

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/tts/JorSayReader.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/tts/JorSayReader.java
@@ -3,24 +3,33 @@ package com.mocha17.slayer.tts;
 import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.media.AudioManager;
 import android.os.Build;
+import android.preference.PreferenceManager;
 import android.speech.tts.TextToSpeech;
-import android.text.TextUtils;
+import android.speech.tts.UtteranceProgressListener;
 
+import com.mocha17.slayer.R;
 import com.mocha17.slayer.SlayerApp;
 import com.mocha17.slayer.utils.Constants;
 import com.mocha17.slayer.utils.Logger;
 
+import java.util.HashMap;
 import java.util.Locale;
 
 /**
  * Created by Chaitanya on 5/21/15.
  */
-public class JorSayReader extends IntentService implements TextToSpeech.OnInitListener {
-    private TextToSpeech tts;
-    private boolean isTTSReady;
+public class JorSayReader extends IntentService implements TextToSpeech.OnInitListener,
+        SharedPreferences.OnSharedPreferenceChangeListener {
 
-    private String toReadOnceReady = "";
+    private TextToSpeech tts;
+    int originalVolume;
+
+    private SharedPreferences defaultSharedPreferences;
+    private boolean prefMaxVolume;
+    private AudioManager audioManager;
 
     public JorSayReader() {
         super("JorSayReader");
@@ -29,11 +38,12 @@ public class JorSayReader extends IntentService implements TextToSpeech.OnInitLi
     @Override
     public void onCreate() {
         super.onCreate();
-        if (SlayerApp.getInstance().getTTSAvailable()) {
-            tts = new TextToSpeech(getApplicationContext(), this);
-            Logger.v("TTS init");
 
-        }
+        defaultSharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+        defaultSharedPreferences.registerOnSharedPreferenceChangeListener(this);
+        prefMaxVolume = defaultSharedPreferences.getBoolean(
+                getString(R.string.pref_key_max_volume), false);
+        audioManager = (AudioManager)getSystemService(Context.AUDIO_SERVICE);
     }
 
     public static void startReadAloud(Context context) {
@@ -44,55 +54,81 @@ public class JorSayReader extends IntentService implements TextToSpeech.OnInitLi
 
     @Override
     protected void onHandleIntent(Intent intent) {
-
         if (Constants.ACTION_MSG_START_READ_ALOUD.equals(intent.getAction())) {
-            String toSay = SlayerApp.getInstance().getNotificationString();
-
-            if (isTTSReady) {
-                Logger.d(this, "Speaking...");
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                    tts.speak(toSay, TextToSpeech.QUEUE_ADD, null, null);
-                } else {
-                    tts.speak(toSay, TextToSpeech.QUEUE_ADD, null);
-                }
-            } else {
-                Logger.d(this, "TTS NOT READY");
-                toReadOnceReady = toSay;
-            }
+            Logger.d(this, "onHandleIntent TTS init");
+            tts = new TextToSpeech(getApplicationContext(), this);
         }
-        Logger.d(this, "shutting down self");
-        shutdownSelf();
     }
 
-    private void shutdownSelf() {
-        if (isTTSReady) {
-            Logger.d(this, "TTS shutdown");
-            tts.shutdown();
-        }
-        stopSelf();
-    }
-
-
-    //TTS
     @Override
     public void onInit(int status) {
         if (status == TextToSpeech.SUCCESS) {
             //TODO Change this to match user locale
             tts.setLanguage(Locale.US);
-
-            isTTSReady = true;
-            Logger.d(this, "TTS READY!");
-            if (!TextUtils.isEmpty(toReadOnceReady)) {
-                Logger.d(this, "TTS READY! READING NOW!");
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                    tts.speak(toReadOnceReady, TextToSpeech.QUEUE_ADD, null, null);
-                } else {
-                    tts.speak(toReadOnceReady, TextToSpeech.QUEUE_ADD, null);
+            Logger.d(this, "TTS ready");
+            /*TODO
+            Volume settings check needs to be done for each notification.
+            If the user turns the volume off, we should abort immediately.
+             */
+            originalVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC);
+            if (prefMaxVolume) {
+                Logger.d(this, "setting volume to max");
+                audioManager.setStreamVolume(AudioManager.STREAM_MUSIC,
+                        audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC), 0);
+            } else {
+                if (originalVolume == 0) {
+                    Logger.d(this, "Max volume isn't selected and device volume is at 0," +
+                            "not reading aloud");
+                    return;
                 }
             }
-        } else {
-            Logger.d(this, "TTS NOT READY");
-            isTTSReady = false;
+            String toRead = SlayerApp.getInstance().getNotificationString();
+            Logger.d(this, "TTS reading now");
+            //Utterance ID should be unique per notification. Could be stored in the DB, or,
+            //alternatively, could be DB row ID.
+            String utteranceID = Long.toString(System.currentTimeMillis());
+            tts.setOnUtteranceProgressListener(new JorSayReaderUtteranceProgressListener());
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                tts.speak(toRead,TextToSpeech.QUEUE_ADD, null, utteranceID);
+            } else {
+                HashMap<String, String> params = new HashMap<>();
+                params.put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, utteranceID);
+                tts.speak(toRead, TextToSpeech.QUEUE_ADD, params);
+            }
+        }
+    }
+
+    private void ttsDone() {
+        Logger.d(this, "ttsDone shutting down");
+        tts.shutdown();
+        //After TTS is done, set volume back to original level
+        Logger.d(this, "ttsDone restoring original volume");
+        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, originalVolume, 0);
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if (getString(R.string.pref_key_max_volume).equals(key)) {
+            prefMaxVolume = defaultSharedPreferences.getBoolean(
+                    getString(R.string.pref_key_max_volume), false);
+        }
+
+    }
+
+    private class JorSayReaderUtteranceProgressListener extends UtteranceProgressListener {
+        @Override
+        public void onStart(String utteranceId) {
+            Logger.d(this, "onStart utteranceId: " + utteranceId);
+        }
+
+        @Override
+        public void onDone(String utteranceId) {
+            ttsDone();
+        }
+
+        @Override
+        public void onError(String utteranceId) {
+            ttsDone();
         }
     }
 }

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/utils/Utils.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/utils/Utils.java
@@ -26,7 +26,16 @@ public class Utils {
         //'global read aloud' is true from now on
         sb.append(context.getString(R.string.status_reading_aloud));
 
-        //2. Add Android Wear info
+        //2. Add volume info
+        sb.append(" ");
+        key = context.getString(R.string.pref_key_max_volume);
+        if (sharedPreferences.getBoolean(key, false)) {
+            sb.append(context.getString(R.string.status_max_volume_on));
+        } else {
+            sb.append(context.getString(R.string.status_max_volume_off));
+        }
+
+        //3. Add Android Wear info
         sb.append(" ");
         key = context.getString(R.string.pref_key_android_wear);
         if (sharedPreferences.getBoolean(key, false)) {
@@ -35,7 +44,7 @@ public class Utils {
             sb.append(context.getString(R.string.status_android_wear_off));
         }
 
-        //3. Add 'apps' info
+        //4. Add 'apps' info
         sb.append(", ");
         key = context.getString(R.string.pref_key_all_apps);
         if (sharedPreferences.getBoolean(key, false)) {

--- a/JorSay/mobile/src/main/res/values/integers.xml
+++ b/JorSay/mobile/src/main/res/values/integers.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer name="max_status_lines">2</integer>
+    <integer name="max_status_lines">3</integer>
 </resources>

--- a/JorSay/mobile/src/main/res/values/strings.xml
+++ b/JorSay/mobile/src/main/res/values/strings.xml
@@ -21,13 +21,16 @@
     <string name="status_not_reading_aloud">Not reading any notifications aloud</string>
     <string name="status_reading_aloud">Reading notifications aloud</string>
 
-    <string name="status_android_wear_on">after Shake Detection</string>
-    <string name="status_android_wear_off">without involving Android Wear device(s)</string>
-
     <string name="status_apps">for %s apps</string>
     <string name="all">all</string>
     <string name="none">none of the</string>
     <string name="status_one_app">for 1 app</string>
+
+    <string name="status_max_volume_on">at maximum volume</string>
+    <string name="status_max_volume_off">at device volume</string>
+
+    <string name="status_android_wear_on">after Shake Detection</string>
+    <string name="status_android_wear_off">without involving Android Wear device(s)</string>
 
     <!-- future features -->
     <string name="status_activity">Reading notifications always</string>
@@ -51,11 +54,14 @@
     'zero' for english does not work. -->
     <string name="pref_apps_summary_one">Reading notifications for 1 app</string>
     <string name="pref_apps_summary">Reading notifications for %1$s apps</string>
-
     <string name="pref_apps_summary_none">No apps selected</string>
     <string name="select_apps_title">Select apps</string>
     <string name="all_apps">All apps</string>
     <string name="select_apps_error">Could not load list of apps. Please try again!</string>
+
+    <string name="pref_key_max_volume" translatable="false">pref_key_max_volume</string>
+    <string name="pref_max_volume">Use maximum volume</string>
+    <string name="pref_max_volume_summary">Read notifications at maximum volume</string>
 
     <string name="pref_key_android_wear" translatable="false">pref_key_android_wear</string>
     <string name="pref_android_wear">Enable Shake Detection</string>

--- a/JorSay/mobile/src/main/res/xml/preferences.xml
+++ b/JorSay/mobile/src/main/res/xml/preferences.xml
@@ -11,6 +11,12 @@
         android:key="@string/pref_key_apps"
         android:title="@string/pref_apps_title" />
 
+    <!-- volume -->
+    <SwitchPreference
+        android:key="@string/pref_key_max_volume"
+        android:title="@string/pref_max_volume"
+        android:summary="@string/pref_max_volume_summary"/>
+
     <!-- Persistent notification -->
     <SwitchPreference
         android:key="@string/pref_key_persistent_notification"


### PR DESCRIPTION
Added user preference to use maximum volume for reading notifications. When selected, maximum volume is used for reading notifications, and volume level is restored back to original value after that. When not selected, if device music volume is 0 (muted), notification is ignored - shake detection or read_aloud isn't triggered.

JorSayReader now has an UtteranceProgressListener to help shutdown TTS after reading is done (or on error.)

Testing done: Verified that the setting value is respected.