### PR TITLE
Reliability improvements - NotificationListener service is now started at app start if user has enabled globalReadAloud

### DIFF
--- a/JorSay/mobile/src/main/AndroidManifest.xml
+++ b/JorSay/mobile/src/main/AndroidManifest.xml
@@ -29,9 +29,11 @@
             </intent-filter>
         </activity>
 
+        <!-- stopWithTask - stop this Service when the Task is removed -->
         <service
             android:name="com.mocha17.slayer.notification.NotificationListener"
             android:exported="false"
+            android:stopWithTask="true"
             android:label="@string/app_name"
             android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
             <intent-filter>

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/MainActivity.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/MainActivity.java
@@ -2,7 +2,6 @@ package com.mocha17.slayer;
 
 import android.app.Notification;
 import android.app.NotificationManager;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -19,7 +18,6 @@ import com.mocha17.slayer.utils.Utils;
 
 public class MainActivity extends AppCompatActivity
         implements SharedPreferences.OnSharedPreferenceChangeListener {
-    private Intent notificationListenerIntent;
     private TextView statusText;
 
     @Override
@@ -30,9 +28,6 @@ public class MainActivity extends AppCompatActivity
         if (toolbar != null) {
             setSupportActionBar(toolbar);
         }
-
-        //Intent for NotificationListener
-        notificationListenerIntent = new Intent(this, NotificationListener.class);
 
         SharedPreferences defaultSharedPreferences =
                 PreferenceManager.getDefaultSharedPreferences(this);
@@ -87,9 +82,9 @@ public class MainActivity extends AppCompatActivity
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         if (getString(R.string.pref_key_global_read_aloud).equals(key)) {
             if (sharedPreferences.getBoolean(key, false)) {
-                startService(notificationListenerIntent);
+                NotificationListener.start(this);
             } else {
-                stopService(notificationListenerIntent);
+                NotificationListener.stop(this);
             }
         }
         statusText.setText(Utils.getStatusText(this, sharedPreferences));

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/setup/SetupActivity.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/setup/SetupActivity.java
@@ -17,10 +17,8 @@ import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.GoogleApiClient.ConnectionCallbacks;
 import com.google.android.gms.common.api.GoogleApiClient.OnConnectionFailedListener;
 import com.google.android.gms.wearable.Wearable;
-import com.mocha17.slayer.R;
-import com.mocha17.slayer.SlayerApp;
-import com.mocha17.slayer.utils.Logger;
 import com.mocha17.slayer.MainActivity;
+import com.mocha17.slayer.R;
 
 
 //https://developer.android.com/google/auth/api-client.html#Starting
@@ -125,10 +123,6 @@ public class SetupActivity extends AppCompatActivity
                         .addConnectionCallbacks(this)
                         .addOnConnectionFailedListener(this)
                         .build();
-                //Set it in Application class so that it can be shared with the Service
-                //TODO This doesn't seem necessary
-                SlayerApp.getInstance().setGoogleApiClient(googleApiClient);
-
                 break;
             case CHECKING_GPS:
                 progressText.setText(getString(R.string.progress_gps));
@@ -171,12 +165,8 @@ public class SetupActivity extends AppCompatActivity
             case TTS_SUCCESS:
                 //This is same as overall setup success as of now.
             case SUCCESS:
-                SlayerApp.getInstance().setTTSAvailable(true);
-                Logger.v("SetupActivity GoogleAPIClient connected? " + googleApiClient.isConnected()
-                        + " " + SlayerApp.getInstance().getGoogleApiClient().isConnected());
-                Logger.v("SetupActivity GoogleAPIClient equals? " + googleApiClient + " "
-                        + SlayerApp.getInstance().getGoogleApiClient());
-                Toast.makeText(this, "Will read notifications \"JorSay\"", Toast.LENGTH_SHORT).show();
+                Toast.makeText(
+                        this, "Will read notifications \"JorSay\"", Toast.LENGTH_SHORT).show();
                 //start MainActivity
                 startActivity(new Intent(this, MainActivity.class));
                 finish();
@@ -184,7 +174,6 @@ public class SetupActivity extends AppCompatActivity
             default:
                 break;
         }
-
     }
 
     @Override


### PR DESCRIPTION
We now use Application instance for right reasons - on app start, the service is started if user has enabled globalReadAloud. The application instance also tracks if the service is running; an AtomicBoolean is set to true from service's onStartCommand to false from onDestroy.

We are intentionally not checking if the service is running in SettingsFragment, while setting the initial state of the globalReadAloud preference. We shouldn't need to - the preference value should now reliably indicate if the service is running. This also means we can remove the AtomicBoolean - but we will keep it a little longer in case if we need it.

Also added a notification in onDestroy to know when Android destroys the service. 

Testing done: Verified that the service is started on cold-start and notifications are read.