### PR TITLE
Check notifications access during setup and display appropriate dialogs

### DIFF
--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/setup/SetupActivity.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/setup/SetupActivity.java
@@ -52,6 +52,7 @@ public class SetupActivity extends AppCompatActivity
         TTS_SETUP,
         TTS_USER_REJECT,
         TTS_SUCCESS,
+        CHECKING_NOTIFICATION_ACCESS,
         SUCCESS;
     }
     private State state;
@@ -163,7 +164,10 @@ public class SetupActivity extends AppCompatActivity
             case TTS_USER_REJECT:
                 break;
             case TTS_SUCCESS:
-                //This is same as overall setup success as of now.
+                updateState(State.CHECKING_NOTIFICATION_ACCESS);
+                break;
+            case CHECKING_NOTIFICATION_ACCESS:
+
             case SUCCESS:
                 Toast.makeText(
                         this, "Will read notifications \"JorSay\"", Toast.LENGTH_SHORT).show();

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/setup/SetupActivity.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/setup/SetupActivity.java
@@ -5,11 +5,14 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.speech.tts.TextToSpeech;
 import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.text.TextUtils;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
@@ -19,24 +22,24 @@ import com.google.android.gms.common.api.GoogleApiClient.OnConnectionFailedListe
 import com.google.android.gms.wearable.Wearable;
 import com.mocha17.slayer.MainActivity;
 import com.mocha17.slayer.R;
-
+import com.mocha17.slayer.utils.Logger;
 
 //https://developer.android.com/google/auth/api-client.html#Starting
 public class SetupActivity extends AppCompatActivity
         implements ConnectionCallbacks, OnConnectionFailedListener {
 
-    // Request code to use when launching the resolution activity
-    private static final int REQUEST_RESOLVE_ERROR = 1001;
-    // Unique tag for the error dialog fragment
-    private static final String DIALOG_ERROR = "dialog_error";
-
-    private static final String STATE_RESOLVING_ERROR = "resolving_error";
-
-    private GoogleApiClient googleApiClient;
-
     private TextView progressText;
 
+    private GoogleApiClient googleApiClient;
+    // Request code to use when launching the resolution activity
+    private static final int GPS_REQUEST_RESOLVE_ERROR = 1001;
+    // Unique tag for the error dialog fragment
+    private static final String GPS_ERROR_DIALOG = "dialog_error";
+    private static final String GPS_STATE_RESOLVING_ERROR = "resolving_error";
+
     private static final int TTS_DATA_CHECK_CODE = 1002;
+
+    private AlertDialog notificationSettingsDialog;
 
     private enum State {
         INIT,
@@ -61,33 +64,47 @@ public class SetupActivity extends AppCompatActivity
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_setup);
-        progressText = (TextView)findViewById(R.id.progressText);
+        Toolbar toolbar = (Toolbar) findViewById(R.id.app_toolbar_setup);
+        if (toolbar != null) {
+            setSupportActionBar(toolbar);
+        }
+
+        progressText = (TextView) findViewById(R.id.progressText);
 
         updateState(State.INIT);
 
         if (savedInstanceState != null
-                && savedInstanceState.getBoolean(STATE_RESOLVING_ERROR, false)) {
+                && savedInstanceState.getBoolean(GPS_STATE_RESOLVING_ERROR, false)) {
             updateState(State.GPS_RESOLVING_ERROR);
         }
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
+    protected void onResume() {
+        super.onResume();
+        /* Do nothing if we are GPS_RESOLVING_ERROR. Else, if we are INIT, start with CHECKING_GPS.
+        If we are not INIT, restore the State.
+         */
         if (state != State.GPS_RESOLVING_ERROR) {
-            updateState(State.CHECKING_GPS);
+            if (state == State.INIT) {
+                Logger.d(this, "onResume updating state to " + State.CHECKING_GPS);
+                updateState(State.CHECKING_GPS);
+            } else {
+                Logger.d(this, "onResume updating state to " + state);
+                updateState(state);
+            }
         }
     }
 
     @Override
-    protected void onStop() {
-        updateState(State.GPS_DISCONNECTED);
-        super.onStop();
+    protected void onPause() {
+        perhapsDismissNotificationSettingDialog();
+        super.onPause();
     }
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == REQUEST_RESOLVE_ERROR) {
+        if (requestCode == GPS_REQUEST_RESOLVE_ERROR) {
             updateState(State.GPS_ERROR_RESOLVED);
             if (resultCode == RESULT_OK) {
                 // Make sure the app is not already connected or attempting to connect
@@ -109,24 +126,26 @@ public class SetupActivity extends AppCompatActivity
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         if (state == State.GPS_RESOLVING_ERROR) {
-            outState.putBoolean(STATE_RESOLVING_ERROR, true);
+            outState.putBoolean(GPS_STATE_RESOLVING_ERROR, true);
         }
     }
 
     //Handles UI updates and state transitions.
     private void updateState(State s) {
         state = s;
-        switch(state) {
+        Logger.d(this, "updateState: " + state);
+        switch (state) {
             case INIT:
+                break;
+            case CHECKING_GPS:
+                progressText.setText(getString(R.string.progress_gps));
                 // Initialize GoogleApiClient instance
                 googleApiClient = new GoogleApiClient.Builder(this)
                         .addApiIfAvailable(Wearable.API)
                         .addConnectionCallbacks(this)
                         .addOnConnectionFailedListener(this)
                         .build();
-                break;
-            case CHECKING_GPS:
-                progressText.setText(getString(R.string.progress_gps));
+                //connect
                 googleApiClient.connect();
                 break;
             case GPS_RESOLVING_ERROR:
@@ -138,6 +157,9 @@ public class SetupActivity extends AppCompatActivity
             case GPS_WEAR_UNAVAILABLE:
                 break;
             case GPS_SUCCESS:
+                Logger.d(this, "GPS_SUCCESS, disconnecting and starting with TTS");
+                //Disconnect GPS
+                updateState(State.GPS_DISCONNECTED);
                 //Start with checking TTS
                 updateState(State.CHECKING_TTS);
                 break;
@@ -164,13 +186,31 @@ public class SetupActivity extends AppCompatActivity
             case TTS_USER_REJECT:
                 break;
             case TTS_SUCCESS:
+                Logger.d(this, "updateState TTS_SUCCESS starting with NOTIFICATION_ACCESS");
                 updateState(State.CHECKING_NOTIFICATION_ACCESS);
                 break;
             case CHECKING_NOTIFICATION_ACCESS:
+                progressText.setText(getString(R.string.progress_notifications));
 
+                /* Reference:
+                http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/
+                android/5.1.0_r1/android/provider/Settings.java#
+                Settings.Secure.0ENABLED_NOTIFICATION_LISTENERS and
+                http://stackoverflow.com/questions/18813321/is-there-a-way-an-app-can-check-if-it-is
+                -allowed-to-access-notifications*/
+                String enabledListeners = Settings.Secure.getString(getContentResolver(),
+                        "enabled_notification_listeners");
+
+                if (TextUtils.isEmpty(enabledListeners) ||
+                        !enabledListeners.contains(getPackageName())) {
+                    //JorSay doesn't have access to Notifications
+                    perhapsShowNotificationSettingDialog();
+                } else {
+                    //JorSay has notifications access, go to Success
+                    updateState(State.SUCCESS);
+                }
+                break;
             case SUCCESS:
-                Toast.makeText(
-                        this, "Will read notifications \"JorSay\"", Toast.LENGTH_SHORT).show();
                 //start MainActivity
                 startActivity(new Intent(this, MainActivity.class));
                 finish();
@@ -178,6 +218,73 @@ public class SetupActivity extends AppCompatActivity
             default:
                 break;
         }
+    }
+
+    private void perhapsShowNotificationSettingDialog() {
+        //This check fixed the android.view.WindowLeaked problem
+        if (notificationSettingsDialog != null && notificationSettingsDialog.isShowing()) {
+            Logger.d(this, "perhapsShowNotificationSettingDialog - already showing, returning");
+            return;
+        }
+       /*Reference:
+        stackoverflow.com/questions/17861979/
+        accessing-android-notificationlistenerservice-settings
+
+        grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/5.1.0_r1/
+        android/provider/Settings.java#Settings.0ACTION_NOTIFICATION_LISTENER_SETTINGS*/
+        Intent intent = new Intent("android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS");
+        if (intent.resolveActivity(getPackageManager()) != null) {
+            //intent can resolve
+            notificationSettingsDialog = getNotificationSettingsDialog(intent);
+        } else {
+            //intent cannot resolve
+            notificationSettingsDialog = getErrorDialog();
+        }
+        notificationSettingsDialog.show();
+    }
+
+    private void perhapsDismissNotificationSettingDialog() {
+        if (notificationSettingsDialog != null && notificationSettingsDialog.isShowing()) {
+            notificationSettingsDialog.dismiss();
+        }
+    }
+
+    //Calling a dismiss() before finish() avoids android.view.WindowLeaked problem
+    private void dismissDialogAndFinish() {
+        notificationSettingsDialog.dismiss();
+        finish();
+    }
+
+    private AlertDialog getNotificationSettingsDialog(final Intent notificationSettingsIntent) {
+        return new AlertDialog.Builder(this, R.style.AppDialogTheme)
+                .setTitle(R.string.notification_access_dialog_title)
+                .setMessage(R.string.notification_access_dialog_text)
+                .setPositiveButton(R.string.notification_access_dialog_ok,
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                startActivity(notificationSettingsIntent);
+                            }
+                        }).setNegativeButton(android.R.string.cancel,
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                dismissDialogAndFinish();
+                            }
+                        }).create();
+    }
+
+    private AlertDialog getErrorDialog() {
+        return new AlertDialog.Builder(this, R.style.AppDialogTheme)
+                .setTitle(R.string.notification_access_dialog_title)
+                .setMessage(R.string.notification_access_dialog_error_text)
+                .setPositiveButton(android.R.string.ok,
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                dismissDialogAndFinish();
+                            }
+                        }).create();
     }
 
     @Override
@@ -192,29 +299,16 @@ public class SetupActivity extends AppCompatActivity
         } else if (result.hasResolution()) {
             try {
                 updateState(State.GPS_RESOLVING_ERROR);
-                result.startResolutionForResult(this, REQUEST_RESOLVE_ERROR);
+                result.startResolutionForResult(this, GPS_REQUEST_RESOLVE_ERROR);
             } catch (IntentSender.SendIntentException e) {
                 // There was an error with the resolution intent. Try again.
                 updateState(State.CHECKING_GPS);
             }
         } else {
             // Show dialog using GooglePlayServicesUtil.getErrorDialog()
-            showErrorDialog(result.getErrorCode());
+            showGPSErrorDialog(result.getErrorCode());
             updateState(State.GPS_RESOLVING_ERROR);
         }
-    }
-
-    // The rest of this code is all about building the error dialog
-
-    /* Creates a dialog for an error message */
-    private void showErrorDialog(int errorCode) {
-        // Create a fragment for the error dialog
-        ErrorDialogFragment dialogFragment = new ErrorDialogFragment();
-        // Pass the error that should be displayed
-        Bundle args = new Bundle();
-        args.putInt(DIALOG_ERROR, errorCode);
-        dialogFragment.setArguments(args);
-        dialogFragment.show(getSupportFragmentManager(), ErrorDialogFragment.class.getSimpleName());
     }
 
     @Override
@@ -227,21 +321,34 @@ public class SetupActivity extends AppCompatActivity
         updateState(State.GPS_SUSPENDED);
     }
 
-    /* A fragment to display an error dialog */
-    public static class ErrorDialogFragment extends DialogFragment {
-        public ErrorDialogFragment() { }
+    /* Creates a dialog for a GP error message */
+    private void showGPSErrorDialog(int errorCode) {
+        // Create a fragment for the error dialog
+        GPSErrorDialogFragment gpsErrorDialogFragment = new GPSErrorDialogFragment();
+        // Pass the error that should be displayed
+        Bundle args = new Bundle();
+        args.putInt(GPS_ERROR_DIALOG, errorCode);
+        gpsErrorDialogFragment.setArguments(args);
+        gpsErrorDialogFragment.show(getSupportFragmentManager(),
+                GPSErrorDialogFragment.class.getSimpleName());
+    }
+
+    /* A fragment to display GPS error dialog */
+    public static class GPSErrorDialogFragment extends DialogFragment {
+        public GPSErrorDialogFragment() {
+        }
 
         @Override
         public Dialog onCreateDialog(Bundle savedInstanceState) {
             // Get the error code and retrieve the appropriate dialog
-            int errorCode = this.getArguments().getInt(DIALOG_ERROR);
+            int errorCode = this.getArguments().getInt(GPS_ERROR_DIALOG);
             return GooglePlayServicesUtil.getErrorDialog(errorCode,
-                    this.getActivity(), REQUEST_RESOLVE_ERROR);
+                    this.getActivity(), GPS_REQUEST_RESOLVE_ERROR);
         }
 
         @Override
         public void onDismiss(DialogInterface dialog) {
-            ((SetupActivity)getActivity()).updateState(State.GPS_USER_REJECT);
+            ((SetupActivity) getActivity()).updateState(State.GPS_USER_REJECT);
         }
     }
 }

--- a/JorSay/mobile/src/main/res/layout/activity_setup.xml
+++ b/JorSay/mobile/src/main/res/layout/activity_setup.xml
@@ -6,6 +6,14 @@
     tools:context=".SetupActivity"
     tools:ignore="MergeRootFrame">
 
+    <!-- ActionBar -->
+    <include
+        android:id="@+id/app_toolbar_setup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        layout="@layout/layout_app_toolbar"
+        android:layout_alignParentTop="true" />
+
     <ProgressBar
         android:id="@+id/progressBar"
         android:layout_marginTop="@dimen/margin_xxlarge"

--- a/JorSay/mobile/src/main/res/values/strings.xml
+++ b/JorSay/mobile/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="progress_init">Initializing</string>
     <string name="progress_gps">Checking Google Play Services</string>
     <string name="progress_tts">Checking Text to Speech</string>
+    <string name="progress_notifications">Checking Notifications access</string>
 
     <string name="capability_read_aloud_notification">capability_read_aloud_notification</string>
 
@@ -70,4 +71,13 @@
         Trigger \'read aloud\' by shaking your Android Wear-wearing wrist</string>
 
     <string name="persistent_notification_text">at your service</string>
+
+    <string name="notification_access_dialog_title">Notification access</string>
+    <string name="notification_access_dialog_text">JorSay needs access to your notifications so that
+        it can read them aloud.</string>
+    <string name="notification_access_dialog_error_text">JorSay cannot find the settings for
+        notification access, and cannot function without it. Please enable notification access for
+        JorSay and then relaunch the app.</string>
+    <string name="notification_access_dialog_ok">Notification Settings</string>
+
 </resources>

--- a/JorSay/mobile/src/main/res/values/styles.xml
+++ b/JorSay/mobile/src/main/res/values/styles.xml
@@ -26,7 +26,8 @@
     default Material color, and your app's accent color is ignored. This is a long-standing
     bug, and people have come up with multiple solutions:
     https://code.google.com/p/android/issues/detail?id=72717
-    http://stackoverflow.com/questions/26608390/android-v21-theme-appcompat-color-accent-is-ignored-no-padding-on-dialogs
+    http://stackoverflow.com/questions/26608390/
+    android-v21-theme-appcompat-color-accent-is-ignored-no-padding-on-dialogs
     https://github.com/afollestad/material-dialogs
     The solution we are using gets us what we want with least cost - we
     have a theme defined for Dialogs that explicitly sets colorAccent. -->


### PR DESCRIPTION
We would ideally like to have the Notification access check dialog as common code, and call it from anywhere if we don't have access. But that refactoring i kept for another day.

Testing done:
1. The notification access dialog shows up if we don't have access to notifications.
2. Tapping on 'Notification Settings' takes user to correct screen.
3. Tapping on Cancel finishes the Activity.
4. On enabling access, the dialog does not show up again during setup.