### PR TITLE
Show a hint when global read aloud is off

### DIFF
--- a/JorSay/.idea/misc.xml
+++ b/JorSay/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <entry_points version="2.0" />
+  </component>
   <component name="ProjectLevelVcsManager" settingsEditedManually="false">
     <OptionsSetting value="true" id="Add" />
     <OptionsSetting value="true" id="Remove" />

--- a/JorSay/mobile/src/main/res/layout/layout_toast.xml
+++ b/JorSay/mobile/src/main/res/layout/layout_toast.xml
@@ -1,0 +1,16 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/toast_layout_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background_transparent">
+
+    <TextView
+        android:id="@+id/toast_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/padding"
+        style="@style/BoldTextStyle"
+        android:textColor="@android:color/white"
+        android:textAppearance="?android:attr/textAppearanceMedium" />
+</RelativeLayout>

--- a/JorSay/mobile/src/main/res/values/colors.xml
+++ b/JorSay/mobile/src/main/res/values/colors.xml
@@ -6,6 +6,7 @@ http://www.google.com/design/spec/style/color.html#color-color-palette -->
     <color name="primary_dark">#FF5033</color>
     <color name="background">#F5F5F5</color>
     <color name="content_background">#EEEEEE</color>
+    <color name="background_transparent">#E6424242</color>
     <color name="navigationBar">#9E9E9E</color>
     <color name="text_primary">#FFFFFF</color>
     <color name="text">#424242</color>

--- a/JorSay/mobile/src/main/res/values/strings.xml
+++ b/JorSay/mobile/src/main/res/values/strings.xml
@@ -16,7 +16,8 @@
     <string name="capability_read_aloud_notification">capability_read_aloud_notification</string>
 
     <string name="not_connected_title">Not connected</string>
-    <string name="not_connected_desc">Not connected to a device that can read notifications aloud</string>
+    <string name="not_connected_desc">Not connected to a device that can
+        read notifications aloud</string>
 
     <!-- Status messages -->
     <string name="status_not_reading_aloud">Not reading any notifications aloud</string>
@@ -32,6 +33,8 @@
 
     <string name="status_android_wear_on">after Shake Detection</string>
     <string name="status_android_wear_off">without involving Android Wear device(s)</string>
+
+    <string name="global_read_aloud_hint">Turn on \'%s\' and configure other options.</string>
 
     <!-- future features -->
     <string name="status_activity">Reading notifications always</string>

--- a/JorSay/wear/wear.iml
+++ b/JorSay/wear/wear.iml
@@ -91,7 +91,7 @@
     <orderEntry type="library" exported="" name="recyclerview-v7-22.0.0" level="project" />
     <orderEntry type="library" exported="" name="support-v4-22.0.0" level="project" />
     <orderEntry type="library" exported="" name="wearable-1.2.0" level="project" />
-    <orderEntry type="library" exported="" name="wearable-1.0.0" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-22.0.0" level="project" />
+    <orderEntry type="library" exported="" name="wearable-1.0.0" level="project" />
   </component>
 </module>


### PR DESCRIPTION
Testing done:
Hint is shown when user reaches the Main Activity and global read aloud is off.
Hint is not shown after orientation changes, and shown again after backing out of Activity and reaching it again.
Hint is not shown after global read aloud is turned on.