### PR TITLE
Reliably read most recent unread notification and also record and restore shake preferences

### DIFF
--- a/JorSay/mobile/src/main/AndroidManifest.xml
+++ b/JorSay/mobile/src/main/AndroidManifest.xml
@@ -73,5 +73,11 @@
             </intent-filter>
         </service>
 
+        <receiver android:name=".notification.db.NotificationDBCleaner">
+            <intent-filter>
+                <action android:name="com.mocha17.slayer.notification.db.NotificationDBCleaner" />
+            </intent-filter>
+        </receiver>
+
     </application>
 </manifest>

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/NotificationListener.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/NotificationListener.java
@@ -133,7 +133,7 @@ public class NotificationListener extends NotificationListenerService
     private NextAction getNextAction(StatusBarNotification statusBarNotification) {
         //Start with global_read_aloud
         if (!prefGlobalReadAloud) {
-            Logger.d(this, "Global read_aloud is off, ignoring");
+            Logger.d(this, "global_read_aloud is off, ignoring");
             return NextAction.IGNORE;
         }
         //global_read_aloud is on
@@ -264,9 +264,9 @@ public class NotificationListener extends NotificationListenerService
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         if (getString(R.string.pref_key_persistent_notification).equals(key)) {
             setPrefPersistentNotification(sharedPreferences);
-            if (prefPersistentNotification) {
-                startForeground(Constants.PERSISTENT_NOTIFICATION_ID,
-                        getPersistentNotification(defaultSharedPreferences));
+            if (prefPersistentNotification && prefGlobalReadAloud) {
+                    startForeground(Constants.PERSISTENT_NOTIFICATION_ID,
+                            getPersistentNotification(defaultSharedPreferences));
             } else {
                 stopForeground(true /*removeNotification*/);
             }
@@ -334,7 +334,7 @@ public class NotificationListener extends NotificationListenerService
         Random r = new Random();
         nm.notify(r.nextInt(), builder.build());
 
-        notificationDBOps.shutdown();
+        notificationDBOps.shutdown(this);
 
         super.onDestroy();
     }

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/db/NotificationDB.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/db/NotificationDB.java
@@ -12,7 +12,7 @@ import com.mocha17.slayer.utils.Logger;
  */
 /*package-private*/ class NotificationDB extends SQLiteOpenHelper {
     public static final String DATABASE_NAME = "NotificationDB.db";
-    private static int DATABASE_VERSION = 1; //to be updated on schema change
+    private static int DATABASE_VERSION = 2; //to be updated on schema change
 
     private static final String TEXT_TYPE = " TEXT";
     private static final String INTEGER_TYPE = " INTEGER";
@@ -31,7 +31,8 @@ import com.mocha17.slayer.utils.Logger;
                     NotificationData.COLUMN_NAME_TEXT_LINES + TEXT_TYPE + COMMA +
                     NotificationData.COLUMN_NAME_SUBTEXT + TEXT_TYPE + COMMA +
                     NotificationData.COLUMN_NAME_TICKER_TEXT + TEXT_TYPE + COMMA +
-                    NotificationData.COLUMN_NAME_WHEN + TEXT_TYPE + " )";
+                    NotificationData.COLUMN_NAME_WHEN + TEXT_TYPE + COMMA +
+                    NotificationData.COLUMN_NAME_NOTIFICATION_READ + INTEGER_TYPE + " )";
 
     private static final String SQL_DELETE_ENTRIES_NOTIFICATION_DATA =
             "DROP TABLE IF EXISTS " + NotificationData.TABLE_NAME;
@@ -48,6 +49,10 @@ import com.mocha17.slayer.utils.Logger;
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         Logger.d(this, "onUpgrade from " + oldVersion + " to " + newVersion);
+        /*Version 2 adds NOTIFICATION_READ flag to DB. We could do something fancy here, like
+        marking all the notifications in the table READ. But, we don't care all that much about
+        prior notifications anyways - they are not going to read later. We are going to delete READ
+        notifications periodically; dropping the table is same as marking notifications as READ. */
         db.execSQL(SQL_DELETE_ENTRIES_NOTIFICATION_DATA);
         DATABASE_VERSION = newVersion;
         onCreate(db);

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/db/NotificationDBCleaner.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/db/NotificationDBCleaner.java
@@ -1,0 +1,48 @@
+package com.mocha17.slayer.notification.db;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import com.mocha17.slayer.utils.Logger;
+
+/**
+ * Created by Chaitanya on 8/1/15.
+ */
+public class NotificationDBCleaner extends BroadcastReceiver {
+    private static final String ACTION_NOTIFICATION_DB_CLEANER =
+            "com.mocha17.slayer.notification.db.NotificationDBCleaner";
+    private static final int ALARM_INTENT_REQUEST_CODE = 1234;
+
+    private static PendingIntent alarmIntent;
+
+    public static void start(Context context) {
+        Logger.d("NotificationDBCleaner - setting up alarm");
+
+        Intent intent = new Intent(ACTION_NOTIFICATION_DB_CLEANER);
+        alarmIntent = PendingIntent.getBroadcast(context, ALARM_INTENT_REQUEST_CODE, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT);
+
+        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        alarmManager.setInexactRepeating(AlarmManager.ELAPSED_REALTIME, 0 /*start now*/,
+                AlarmManager.INTERVAL_DAY, alarmIntent);
+    }
+
+    public static void stop(Context context) {
+        if (alarmIntent != null) {
+            AlarmManager alarmManager =
+                    (AlarmManager)context.getSystemService(Context.ALARM_SERVICE);
+            Logger.d("NotificationDBCleaner - canceling alarm");
+            alarmManager.cancel(alarmIntent);
+        }
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (ACTION_NOTIFICATION_DB_CLEANER.equals(intent.getAction())) {
+            NotificationDBOps.get(context).removeReadNotifications();
+        }
+    }
+}

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/db/NotificationDBContract.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/db/NotificationDBContract.java
@@ -32,5 +32,8 @@ public class NotificationDBContract {
         //----- Fields from Notification -----
         public static final String COLUMN_NAME_TICKER_TEXT = "ticketText";
         public static final String COLUMN_NAME_WHEN = "notificationWhen";
+
+        //----- Fields for bookkeeping -----
+        public static final String COLUMN_NAME_NOTIFICATION_READ = "notificationRead";
     }
 }

--- a/JorSay/wear/src/main/java/com/mocha17/slayer/utils/Constants.java
+++ b/JorSay/wear/src/main/java/com/mocha17/slayer/utils/Constants.java
@@ -25,7 +25,7 @@ public class Constants {
     public static final String SHAKE_INTENSITY_HIGH = "SHAKE_INTENSITY_HIGH";
     public static final float SHAKE_INTENSITY_LOW_VALUE = 2f;
     public static final float SHAKE_INTENSITY_MED_VALUE = 6f;
-    public static final float SHAKE_INTENSITY_HIGH_VALUE = 8f;
+    public static final float SHAKE_INTENSITY_HIGH_VALUE = 9f;
     public static final float SHAKE_INTENSITY_DEFAULT = SHAKE_INTENSITY_MED_VALUE;
 
     //read aloud


### PR DESCRIPTION
Couple of important changes:
1. Reliably reading most recent unread notification:
Previously, we were retrieving a notification and deleting it, even before exiting the method. We were relying on data being copied into the cursor. This mechanism worked generally well, but had a very subtle and hard-to-reproduce defect - at times, an older notification would be read, not the most recent one. Now, we are no longer deleting the row immediately. Instead, we track whether a notification is read, and we delete all read notifications once a day.
2. Record and restore Shake preferences:
We introduced shake intensity and detection duration preferences, but we were not recording them anywhere on the Wear side. We are now storing and restoring the values on the Wear side.

Testing done:
1. Verified that notifications are marked read, read notifications are deleted (tested by reducing Alarm interval to 10 seconds) and most recent unread notification is read.
2. Shake preferences are accurately applied.