### PR TITLE
Enable Shake Detection by default

### DIFF
--- a/JorSay/mobile/build.gradle
+++ b/JorSay/mobile/build.gradle
@@ -8,7 +8,7 @@ android {
         applicationId "com.mocha17.slayer"
         minSdkVersion 19
         targetSdkVersion 22
-        versionCode 6
+        versionCode 7
         versionName "1.0"
     }
     buildTypes {

--- a/JorSay/mobile/src/main/AndroidManifest.xml
+++ b/JorSay/mobile/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mocha17.slayer"
-    android:versionCode="6"
+    android:versionCode="7"
     android:versionName="1.0.0" >
 
     <!-- KITKAT to LOLLIPOP_MR1 -->

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/SlayerApp.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/SlayerApp.java
@@ -31,6 +31,16 @@ public class SlayerApp extends Application {
             instance = this;
         }
         defaultSharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+
+        /*Following two checks are important enough to be done in Application.onCreate():
+        1. Set 'Enable shake detection' to true if it is never set. (We are not overwriting
+        user's preference; just setting it to true by default.)
+        2. Start the NotificationListenerService if user has enabled 'read aloud'*/
+        String enableShakeDetection = getString(R.string.pref_key_android_wear);
+        if (!defaultSharedPreferences.contains(enableShakeDetection)) {
+            Logger.d(this, "Shake Detection was never set before, setting it to true");
+            defaultSharedPreferences.edit().putBoolean(enableShakeDetection, true).apply();
+        }
         boolean prefGlobalReadAloud = defaultSharedPreferences.getBoolean(
                 getString(R.string.pref_key_global_read_aloud), false);
         if (prefGlobalReadAloud && !isNotificationListenerRunning()) {
@@ -46,6 +56,6 @@ public class SlayerApp extends Application {
     }
 
     public void setNotificationListenerRunning(boolean isRunning) {
-        isNotificationListenerRunning.compareAndSet(false, true);
+        isNotificationListenerRunning.set(isRunning);
     }
 }

--- a/JorSay/wear/build.gradle
+++ b/JorSay/wear/build.gradle
@@ -9,7 +9,7 @@ android {
         applicationId "com.mocha17.slayer"
         minSdkVersion 19
         targetSdkVersion 22
-        versionCode 6
+        versionCode 7
         versionName "1.0"
     }
     buildTypes {

--- a/JorSay/wear/src/main/AndroidManifest.xml
+++ b/JorSay/wear/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mocha17.slayer"
-    android:versionCode="6"
+    android:versionCode="7"
     android:versionName="1.0.0" >
 
     <!-- KITKAT to LOLLIPOP_MR1 -->


### PR DESCRIPTION
Enabling Shake Detection if it was never set.
Testing done:
1. On a fresh install, shake detection is on
2. Once user modifies the value, it is not overwritten on a cold-start.