### PR TITLE
Major improvements in 'reading aloud'

### DIFF
--- a/JorSay/mobile/build.gradle
+++ b/JorSay/mobile/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.mocha17.slayer"
         minSdkVersion 19
         targetSdkVersion 22
-        versionCode 9
-        versionName "1.5"
+        versionCode 11
+        versionName "1.7"
     }
     buildTypes {
         release {

--- a/JorSay/mobile/src/main/AndroidManifest.xml
+++ b/JorSay/mobile/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mocha17.slayer"
-    android:versionCode="9"
-    android:versionName="1.5.0" >
+    android:versionCode="11"
+    android:versionName="1.7" >
 
     <!-- KITKAT to LOLLIPOP_MR1 -->
     <uses-sdk

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/MainActivity.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/MainActivity.java
@@ -102,6 +102,10 @@ public class MainActivity extends AppCompatActivity
         if(snoozeUpdateReceiver != null) {
             LocalBroadcastManager.getInstance(this).unregisterReceiver(snoozeUpdateReceiver);
         }
+        //stop any ongoing animation
+        if (statusAnimation != null && statusAnimation.isRunning()) {
+            statusAnimation.cancel();
+        }
         super.onPause();
     }
 

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/db/NotificationDB.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/db/NotificationDB.java
@@ -12,7 +12,7 @@ import com.mocha17.slayer.utils.Logger;
  */
 /*package-private*/ class NotificationDB extends SQLiteOpenHelper {
     public static final String DATABASE_NAME = "NotificationDB.db";
-    private static int DATABASE_VERSION = 2; //to be updated on schema change
+    private static int DATABASE_VERSION = 3; //to be updated on schema change
 
     private static final String TEXT_TYPE = " TEXT";
     private static final String INTEGER_TYPE = " INTEGER";
@@ -21,8 +21,9 @@ import com.mocha17.slayer.utils.Logger;
     private static final String SQL_CREATE_ENTRIES_NOTIFICATION_DATA =
             "CREATE TABLE " + NotificationData.TABLE_NAME + " (" +
                     NotificationData._ID + INTEGER_TYPE + " PRIMARY KEY," +
-                    NotificationData.COLUMN_NAME_NOTIFICATION_ID + INTEGER_TYPE + COMMA +
                     NotificationData.COLUMN_NAME_PACKAGE_NAME + TEXT_TYPE + COMMA +
+                    NotificationData.COLUMN_NAME_NOTIFICATION_ID + INTEGER_TYPE + COMMA +
+                    NotificationData.COLUMN_NAME_NOTIFICATION_TAG + INTEGER_TYPE + COMMA +
                     NotificationData.COLUMN_NAME_TITLE + TEXT_TYPE + COMMA +
                     NotificationData.COLUMN_NAME_TEXT + TEXT_TYPE + COMMA +
                     NotificationData.COLUMN_NAME_TITLE_BIG + TEXT_TYPE + COMMA +
@@ -52,7 +53,8 @@ import com.mocha17.slayer.utils.Logger;
         /*Version 2 adds NOTIFICATION_READ flag to DB. We could do something fancy here, like
         marking all the notifications in the table READ. But, we don't care all that much about
         prior notifications anyways - they are not going to read later. We are going to delete READ
-        notifications periodically; dropping the table is same as marking notifications as READ. */
+        notifications periodically; dropping the table is same as marking notifications as READ.
+        Version 3 adds NOTIFICATION_TAG to DB.*/
         db.execSQL(SQL_DELETE_ENTRIES_NOTIFICATION_DATA);
         DATABASE_VERSION = newVersion;
         onCreate(db);

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/db/NotificationDBContract.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/db/NotificationDBContract.java
@@ -10,15 +10,15 @@ public class NotificationDBContract {
         //private Constructor to prevent instantiation
     }
 
-    //For the Notifications table - currently, the only table we have
+    //For the Notifications table - currently, the only table we have.
+    //BaseColumns_ID is the table key
     public static abstract class NotificationData implements BaseColumns {
         public static final String TABLE_NAME = "notificationsTable";
 
         //----- Fields from StatusBarNotification -----
-        /*NOTIFICATION_ID and PACKAGE_NAME are our uniqueness test. We are using
-        BaseColumns._ID for table key.*/
-        public static final String COLUMN_NAME_NOTIFICATION_ID = "notificationId";
         public static final String COLUMN_NAME_PACKAGE_NAME = "packageName";
+        public static final String COLUMN_NAME_NOTIFICATION_ID = "notificationId";
+        public static final String COLUMN_NAME_NOTIFICATION_TAG = "notificationTag";
 
         //----- Fields from Notification Extras -----
         public static final String COLUMN_NAME_TITLE = "title";
@@ -30,7 +30,7 @@ public class NotificationDBContract {
         public static final String COLUMN_NAME_SUBTEXT= "subtext";
 
         //----- Fields from Notification -----
-        public static final String COLUMN_NAME_TICKER_TEXT = "ticketText";
+        public static final String COLUMN_NAME_TICKER_TEXT = "tickerText";
         public static final String COLUMN_NAME_WHEN = "notificationWhen";
 
         //----- Fields for bookkeeping -----

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/db/NotificationDBOps.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/notification/db/NotificationDBOps.java
@@ -9,10 +9,16 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
-import android.text.TextUtils;
+import android.util.Pair;
 
 import com.mocha17.slayer.notification.db.NotificationDBContract.NotificationData;
 import com.mocha17.slayer.utils.Logger;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 
 /**
  * For working with the NotificationDB.<br>
@@ -28,9 +34,7 @@ public class NotificationDBOps {
     private static final int NOTIFICATION_READ = 2;
 
     private static final String [] COLUMN_ROW_ID = {NotificationData._ID};
-    //(package+notificationID)
-    private static final String IS_PRESENT_SELECTION = NotificationData.COLUMN_NAME_PACKAGE_NAME
-            + "=?" + " and " + NotificationData.COLUMN_NAME_NOTIFICATION_ID + "=?";
+
     private static final String WHERE_ROW_ID = NotificationData._ID + "=?";
     private static final String IS_UNREAD_SELECTION =
             NotificationData.COLUMN_NAME_NOTIFICATION_READ + "=?";
@@ -49,183 +53,343 @@ public class NotificationDBOps {
         notificationDBOpenHelper = new NotificationDB(context);
     }
 
-    /** Stores the notification data in DB. If (package+id) combination is already present, existing
-     * record will be updated. Can be called from main thread.
+    /** Stores the notification data in DB, if identical data isn't already present.
+     * Identical data means packageName and user-visible data from Notification.
+     * <br>This method blocks on getting the database, and should not be called from main thread.
      * @param sbn the notification to be stored
+     * @return whether storing the notification was successful
      */
-    public void storeNotification(StatusBarNotification sbn) {
-        if (sbn == null) {
-            return;
-        }
-
-        Notification notification = sbn.getNotification();
-        Bundle notificationExtras = notification.extras;
-
-        ContentValues cv = new ContentValues();
-        cv.put(NotificationData.COLUMN_NAME_NOTIFICATION_ID, sbn.getId());
-        cv.put(NotificationData.COLUMN_NAME_PACKAGE_NAME, sbn.getPackageName());
-        cv.put(NotificationData.COLUMN_NAME_TITLE,
-                notificationExtras.getString(Notification.EXTRA_TITLE));
-        CharSequence text = notificationExtras.getCharSequence(Notification.EXTRA_TEXT);
-        if (!TextUtils.isEmpty(text)) {
-            cv.put(NotificationData.COLUMN_NAME_TEXT, text.toString());
-        }
-        cv.put(NotificationData.COLUMN_NAME_TITLE_BIG,
-                notificationExtras.getString(Notification.EXTRA_TITLE_BIG));
-        cv.put(NotificationData.COLUMN_NAME_BIG_TEXT,
-                notificationExtras.getString(Notification.EXTRA_BIG_TEXT));
-        cv.put(NotificationData.COLUMN_NAME_SUMMARY,
-                notificationExtras.getString(Notification.EXTRA_SUMMARY_TEXT));
-        cv.put(NotificationData.COLUMN_NAME_TEXT_LINES,
-                getString(notificationExtras.getCharSequenceArray(Notification.EXTRA_TEXT_LINES)));
-        cv.put(NotificationData.COLUMN_NAME_SUBTEXT,
-                notificationExtras.getString(Notification.EXTRA_SUB_TEXT));
-        if (!TextUtils.isEmpty(notification.tickerText)) {
-            cv.put(NotificationData.COLUMN_NAME_TICKER_TEXT, notification.tickerText.toString());
-        }
-        cv.put(NotificationData.COLUMN_NAME_WHEN, Long.toString(notification.when));
-        cv.put(NotificationData.COLUMN_NAME_NOTIFICATION_READ, NOTIFICATION_UNREAD);
-
-        insertOrUpdate(cv);
-    }
-
-    /**For doing getWritableDatabase() in a separate thread as needed.*/
-    private void insertOrUpdate(final ContentValues cv) {
+    public boolean storeNotification(final StatusBarNotification sbn) {
+        perhapsInitDB(); //do not forget calling perhapsInitDB()!
         if (notificationDB != null && notificationDB.isOpen()) {
-            insertOrUpdateInternal(cv);
-        } else {
-            new Thread() {
-                @Override
-                public void run() {
-                    Logger.d(NotificationDBOps.this, "insertOrUpdate - getting WritableDatabase");
-                    synchronized (instance) {
-                        notificationDB = notificationDBOpenHelper.getWritableDatabase();
-                    }
-                    insertOrUpdateInternal(cv);
-                }
-            }.start();
+            return storeNotificationInternal(sbn);
         }
+        return false;
     }
 
-    /** For actually performing the insertOrUpdate operation */
-    private void insertOrUpdateInternal(ContentValues cv) {
-        //Check if this (package+id) is already present
-        String [] selectionArgs = new String[] {
-            cv.getAsString(NotificationData.COLUMN_NAME_PACKAGE_NAME),
-            cv.getAsString(NotificationData.COLUMN_NAME_NOTIFICATION_ID)
-        };
-        /* public Cursor query (String table, String[] columns, String selection, String[]
-        selectionArgs, String groupBy, String having, String orderBy) */
-        Cursor cursor = notificationDB.query(NotificationData.TABLE_NAME, COLUMN_ROW_ID,
-                IS_PRESENT_SELECTION, selectionArgs, null, null, ORDER_BY_WHEN);
-        if (cursor != null && cursor.getCount() > 0) {
-            if (cursor.getCount() > 1) {
-                //Will happen only when tag is playing a role.
-                //developer.android.com/reference/android/app/NotificationManager.html#
-                // notify(java.lang.String, int, android.app.Notification)
-                //TODO - Add Tag to the uniqueness test
-                Logger.w(this, "insertOrUpdateInternal found more than one notifications for " +
-                        cv.get(NotificationData.COLUMN_NAME_PACKAGE_NAME) + ", " +
-                        cv.get(NotificationData.COLUMN_NAME_NOTIFICATION_ID) +
-                        ", updating most recent one");
-            }
-            cursor.moveToFirst();
-            int rowId = cursor.getInt(cursor.getColumnIndex(NotificationData._ID));
-
-            Logger.d(NotificationDBOps.this, "insertOrUpdateInternal " +
-                    cv.get(NotificationData.COLUMN_NAME_PACKAGE_NAME) + ", " +
-                    cv.get(NotificationData.COLUMN_NAME_NOTIFICATION_ID) +
-                    " already present, updating");
-
-            notificationDB.update(NotificationData.TABLE_NAME, cv, WHERE_ROW_ID,
-                    new String[]{Integer.toString(rowId)});
-        } else {
-            Logger.d(NotificationDBOps.this, "insertOrUpdateInternal " +
-                    cv.get(NotificationData.COLUMN_NAME_PACKAGE_NAME) + ", " +
-                    cv.get(NotificationData.COLUMN_NAME_NOTIFICATION_ID) +
-                    " inserting in DB");
-            notificationDB.insert(NotificationData.TABLE_NAME, null, cv);
+    /** For actually storing the notification in DB. A notification already present isn't stored.
+     * @return whether the notification was stored. */
+    private boolean storeNotificationInternal(StatusBarNotification sbn) {
+        ContentValues cv = toContentValues(sbn, true/*isUnread*/);
+        if (cv == null) {
+            return false;
         }
+
+        Pair<String, String[]> selectionParams = getIsPresentSelectionParams(cv);
+        Cursor cursor = notificationDB.query(NotificationData.TABLE_NAME, COLUMN_ROW_ID,
+                selectionParams.first/*selection*/, selectionParams.second/*selectionArgs*/,
+                null, null, null);
+
+        if (cursor != null && cursor.moveToFirst()) {
+            Logger.d(this, "storeNotificationInternal found notification from " +
+                    cv.get(NotificationData.COLUMN_NAME_PACKAGE_NAME) + ", not storing again");
+            if (!cursor.isClosed()) {
+                cursor.close();
+            }
+            return false;
+        }
+        Logger.d(NotificationDBOps.this, "storeNotificationInternal " +
+                cv.get(NotificationData.COLUMN_NAME_PACKAGE_NAME) + ", " +
+                cv.get(NotificationData.COLUMN_NAME_NOTIFICATION_ID) + " inserting in DB");
+        long rowId = notificationDB.insert(NotificationData.TABLE_NAME, null, cv);
+        return (rowId != -1);
     }
 
     /**
      * Queries the database, and returns the most recent unread notification (sorted by 'when').
      * <br>Do not call this method from main thread as it blocks on initializing the
      * SQLiteDatabase object if needed. */
-
-    /*storeNotification() above can be safely called from main thread as it does the
-    getWritableDatabase() call from a separate thread if needed. (The call itself is synchronized on
-    the singleton NotificationDBOps instance object.) We could have done the same for query, but it
-    presents a complication - returning a value from the thread, or blocking the calling thread till
-    either SQLiteDatabase object is initialized or the query result is available. We could go for
-    ExecutorService+Callable+Future, but then the code gets complex and with complexity, the
-    potential for errors and problems increases.
-    So, what's the solution? We are taking the benefit of the fact that none of our queries are
-    coming from main thread - they are coming from JorSayReader, which is an IntentService. The
-    getWritableDatabase() call in this method can safely block or take longer - it is the caller's
-    responsibility to make sure that this method is not called on main thread.
-
-    This, in combination with having only one SQLiteDatabase and only one SQLiteOpenHelper, is our
-    strategy for dealing with long-running DB related operations and DB being accessed from multiple
-    threads. We will tweak/change this based on how it works out for the app.*/
-
     public Cursor getMostRecentNotification() {
-        synchronized (instance) {
-            //the null check is also synchronized, preventing multiple initializations.
-            //In all likelihood, the storeNotification() method would have initialized this as
-            //queries happen from the reader, which is triggered from the notification listener.
-            if (notificationDB == null || !notificationDB.isOpen()) {
-                Logger.d(NotificationDBOps.this, "getMostRecentNotification - " +
-                        "getting WritableDatabase");
-                notificationDB = notificationDBOpenHelper.getWritableDatabase();
-            }
+        perhapsInitDB();
+        if (notificationDB != null && notificationDB.isOpen()) {
+            final String [] selectionArgs = {Integer.toString(NOTIFICATION_UNREAD)};
+            /* public Cursor query (String table, String[] columns, String selection,
+            String[] selectionArgs, String groupBy, String having, String orderBy, String limit) */
+            return notificationDB.query(NotificationData.TABLE_NAME, null, IS_UNREAD_SELECTION,
+                    selectionArgs, null, null, ORDER_BY_WHEN,
+                    LIMIT_FOR_MOST_RECENT); //get 1 most recent notification
         }
-
-        /* public Cursor query (String table, String[] columns, String selection, String[]
-        selectionArgs, String groupBy, String having, String orderBy, String limit) */
-        String [] selectionArgs = {Integer.toString(NOTIFICATION_UNREAD)};
-        return notificationDB.query(NotificationData.TABLE_NAME, null, IS_UNREAD_SELECTION,
-                        selectionArgs, null, null, ORDER_BY_WHEN,
-                        LIMIT_FOR_MOST_RECENT); //get 1 most recent notification
+        return null;
     }
 
+    /** Blocks on initializing the database object if needed,
+     * and should not be called from main thread. */
     public void markNotificationRead(long rowId) {
-        Logger.d(NotificationDBOps.this, "markNotificationRead for rowId: " + rowId);
-        ContentValues cv = new ContentValues();
-        cv.put(NotificationData.COLUMN_NAME_NOTIFICATION_READ, NOTIFICATION_READ);
-        notificationDB.update(NotificationData.TABLE_NAME, cv, WHERE_ROW_ID,
-                new String[]{Long.toString(rowId)});
+        perhapsInitDB();
+        if (notificationDB != null && notificationDB.isOpen()) {
+            Logger.d(NotificationDBOps.this, "markNotificationRead for rowId: " + rowId);
+            final String [] selectionArgs = new String[]{Long.toString(rowId)};
+            final ContentValues cv = new ContentValues();
+            cv.put(NotificationData.COLUMN_NAME_NOTIFICATION_READ, NOTIFICATION_READ);
+
+            notificationDB.update(NotificationData.TABLE_NAME, cv, WHERE_ROW_ID, selectionArgs);
+        }
     }
 
-    public void removeNotification(String packageName, int notificationId) {
-        if(TextUtils.isEmpty(packageName)) {
-            return;
-        }
-        synchronized (instance) {
-            if (notificationDB == null || !notificationDB.isOpen()) {
-                Logger.d(NotificationDBOps.this, "removeNotification - " +
-                        "getting WritableDatabase");
-                notificationDB = notificationDBOpenHelper.getWritableDatabase();
+    public void removeNotification(StatusBarNotification sbn) {
+        perhapsInitDB();
+        if (notificationDB != null && notificationDB.isOpen()) {
+            ContentValues cv = toContentValues(sbn, false/*isUnread*/);
+            if (cv == null) {
+                return;
             }
+            Pair<String, String[]> selectionParams = getSelectionParamsForDelete(cv);
+            if (selectionParams == null) {
+                return;
+            }
+            notificationDB.delete(NotificationData.TABLE_NAME,
+                   selectionParams.first/*selection*/, selectionParams.second/*selectionArgs*/);
         }
-        String [] selectionArgs = new String[] {packageName, Integer.toString(notificationId)};
-        notificationDB.delete(NotificationData.TABLE_NAME, IS_PRESENT_SELECTION, selectionArgs);
     }
 
     public void removeReadNotifications() {
-        synchronized (instance) {
-            if (notificationDB == null || !notificationDB.isOpen()) {
-                Logger.d(NotificationDBOps.this, "removeReadNotifications - " +
-                        "getting WritableDatabase");
-                notificationDB = notificationDBOpenHelper.getWritableDatabase();
+        perhapsInitDB();
+        if (notificationDB != null && notificationDB.isOpen()) {
+            String [] selectionArgs = new String[] {Integer.toString(NOTIFICATION_READ)};
+            notificationDB.delete(NotificationData.TABLE_NAME, IS_UNREAD_SELECTION, selectionArgs);
+        }
+    }
+
+    private ContentValues toContentValues(StatusBarNotification sbn, boolean isUnread) {
+        if (sbn == null) {
+            return null;
+        }
+
+        Notification notification = sbn.getNotification();
+        Bundle notificationExtras = notification.extras;
+
+        ContentValues cv = new ContentValues();
+        cv.put(NotificationData.COLUMN_NAME_PACKAGE_NAME, sbn.getPackageName());
+        cv.put(NotificationData.COLUMN_NAME_NOTIFICATION_ID, sbn.getId());
+        cv.put(NotificationData.COLUMN_NAME_NOTIFICATION_TAG, sbn.getTag());
+        CharSequence title = notificationExtras.getCharSequence(Notification.EXTRA_TITLE);
+        if (title != null) {
+            cv.put(NotificationData.COLUMN_NAME_TITLE, title.toString());
+        }
+        CharSequence text = notificationExtras.getCharSequence(Notification.EXTRA_TEXT);
+        if (text != null) {
+            cv.put(NotificationData.COLUMN_NAME_TEXT, text.toString());
+        }
+        CharSequence bigTitle = notificationExtras.getCharSequence(Notification.EXTRA_TITLE_BIG);
+        if (bigTitle != null) {
+            cv.put(NotificationData.COLUMN_NAME_TITLE_BIG, bigTitle.toString());
+        }
+        CharSequence bigText = notificationExtras.getCharSequence(Notification.EXTRA_BIG_TEXT);
+        if (bigText != null) {
+            cv.put(NotificationData.COLUMN_NAME_BIG_TEXT, bigText.toString());
+        }
+        CharSequence summary = notificationExtras.getCharSequence(Notification.EXTRA_SUMMARY_TEXT);
+        if (summary != null) {
+            cv.put(NotificationData.COLUMN_NAME_SUMMARY, summary.toString());
+        }
+        String textLines = charSequenceArrayToString(
+                notificationExtras.getCharSequenceArray(Notification.EXTRA_TEXT_LINES));
+        if (textLines != null) {
+            cv.put(NotificationData.COLUMN_NAME_TEXT_LINES, textLines);
+        }
+        CharSequence subText = notificationExtras.getCharSequence(Notification.EXTRA_SUB_TEXT);
+        if (subText != null) {
+            cv.put(NotificationData.COLUMN_NAME_SUBTEXT, subText.toString());
+        }
+        if (notification.tickerText != null) {
+            cv.put(NotificationData.COLUMN_NAME_TICKER_TEXT, notification.tickerText.toString());
+        }
+        cv.put(NotificationData.COLUMN_NAME_WHEN, Long.toString(notification.when));
+        cv.put(NotificationData.COLUMN_NAME_NOTIFICATION_READ,
+                isUnread?NOTIFICATION_UNREAD:NOTIFICATION_READ);
+
+        return cv;
+    }
+
+    /**@return A Pair of selection clause and selectionArgs for 'is present' query<br>*/
+    /*This method generates selection clause and selectionArgs *in tandem*, based on the data in the
+    incoming notification.
+    Why this particular approach?
+    1. A row in the table could have null value for any of the columns. This is something we want to
+    express/account for when doing the 'is present' query. Say TITLE is null for the incoming
+    notification. We want the query to return a row where title is (strictly) null, not 'null OR
+    someText' or "null" the String, or anything else.
+    2. The usual approach is to have the selection clause defined as a static final String, and
+    selectionArgs could then be created from the ContentValues. This doesn't work -
+        2.1 An Exception is generated if a selectionArg is null:
+        java.lang.IllegalArgumentException: the bind value at index <index> is null
+        2.2 SelectionArg cannot be "null" the String, because that wouldn't match a null in the row.
+        2.3 Selection clause cannot be 'is null or =?' because this too results in the Exception.
+    3. Android SQLite doesn't seem to do great with nulls - stackoverflow.com/a/15954695/299988
+    4. The solution is to generate a selection clause which has 'is null' for a null field in the
+    notification, and has "=?" for a field that is present in the notification.
+    5. On the surface, simplifying this by replacing the null by a custom value - say "null"; seems
+    possible. However, that requires everyone who uses this DB to understand the custom value and
+    implement logic to disregard it - it creates this ghastly dependency. Current approach doesn't
+    impose such restrictions on DB's users. */
+    private Pair<String, String[]> getIsPresentSelectionParams(ContentValues cv) {
+        StringBuilder selection = new StringBuilder();
+        List<String> selectionArgs = new LinkedList<>();
+
+        selection.append(NotificationData.COLUMN_NAME_PACKAGE_NAME);
+        if (cv.getAsString(NotificationData.COLUMN_NAME_PACKAGE_NAME) != null) {
+            selection.append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_PACKAGE_NAME));
+        } else {
+            selection.append(" is null");
+        }
+        selection.append(" and ").append(NotificationData.COLUMN_NAME_TITLE);
+        if (cv.getAsString(NotificationData.COLUMN_NAME_TITLE) != null) {
+            selection.append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_TITLE));
+        } else {
+            selection.append(" is null");
+        }
+        selection.append(" and ").append(NotificationData.COLUMN_NAME_TEXT);
+        if (cv.getAsString(NotificationData.COLUMN_NAME_TEXT) != null) {
+            selection.append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_TEXT));
+        } else {
+            selection.append(" is null");
+        }
+        selection.append(" and ").append(NotificationData.COLUMN_NAME_TITLE_BIG);
+        if (cv.getAsString(NotificationData.COLUMN_NAME_TITLE_BIG) != null) {
+            selection.append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_TITLE_BIG));
+        } else {
+            selection.append(" is null");
+        }
+        selection.append(" and ").append(NotificationData.COLUMN_NAME_BIG_TEXT);
+        if (cv.getAsString(NotificationData.COLUMN_NAME_BIG_TEXT) != null) {
+            selection.append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_BIG_TEXT));
+        } else {
+            selection.append(" is null");
+        }
+        selection.append(" and ").append(NotificationData.COLUMN_NAME_SUMMARY);
+        if (cv.getAsString(NotificationData.COLUMN_NAME_SUMMARY) != null) {
+            selection.append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_SUMMARY));
+        } else {
+            selection.append(" is null");
+        }
+        selection.append(" and ").append(NotificationData.COLUMN_NAME_TEXT_LINES);
+        if (cv.getAsString(NotificationData.COLUMN_NAME_TEXT_LINES) != null) {
+            selection.append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_TEXT_LINES));
+        } else {
+            selection.append(" is null");
+        }
+        selection.append(" and ").append(NotificationData.COLUMN_NAME_SUBTEXT);
+        if (cv.getAsString(NotificationData.COLUMN_NAME_SUBTEXT) != null) {
+            selection.append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_SUBTEXT));
+        } else {
+            selection.append(" is null");
+        }
+        String [] selectionArgsArr = new String[selectionArgs.size()];
+        return new Pair<>(selection.toString(), selectionArgs.toArray(selectionArgsArr));
+    }
+
+    /* Similar to getIsPresentSelectionParams(). Crucial difference - doesn't add 'is null'.
+    Why? Because, the StatusBarNotification we get in onNotificationRemoved() is "light" - it
+    doesn't contain some of the heavier fields. Our tests show bigText missing, and documentation
+    mentions largeIcon etc. When it comes to not storing duplicates, we want an exact match - if
+    a field isn't present in the received StatusBarNotification, it must be null in our records.
+    But for deleting, we can only match the fields given to us and cannot have the exact test.*/
+    private Pair<String, String[]> getSelectionParamsForDelete(ContentValues cv) {
+        StringBuilder selection = new StringBuilder();
+        List<String> selectionArgs = new LinkedList<>();
+
+        if (cv.getAsString(NotificationData.COLUMN_NAME_PACKAGE_NAME) == null) {
+            //We will bail if there's no packageName.
+            /*We are being slightly lazy here. We are constructing the selection String, and it
+            would start with 'and' if there's no packageName and wouldn't be valid. We are
+            1. choosing to rely on the fact that packageName will always be there and thus
+            2. choosing not to have additional logic for adding/not adding each 'and'.*/
+            return null;
+        }
+        if (cv.getAsString(NotificationData.COLUMN_NAME_PACKAGE_NAME) != null) {
+            selection.append(NotificationData.COLUMN_NAME_PACKAGE_NAME);
+            selection.append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_PACKAGE_NAME));
+        }
+        if (cv.getAsString(NotificationData.COLUMN_NAME_TITLE) != null) {
+            selection.append(" and ")
+                    .append(NotificationData.COLUMN_NAME_TITLE)
+                    .append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_TITLE));
+        }
+        if (cv.getAsString(NotificationData.COLUMN_NAME_TEXT) != null) {
+            selection.append(" and ")
+                    .append(NotificationData.COLUMN_NAME_TEXT)
+                    .append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_TEXT));
+        }
+        if (cv.getAsString(NotificationData.COLUMN_NAME_TITLE_BIG) != null) {
+            selection.append(" and ")
+                    .append(NotificationData.COLUMN_NAME_TITLE_BIG)
+                    .append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_TITLE_BIG));
+        }
+        if (cv.getAsString(NotificationData.COLUMN_NAME_BIG_TEXT) != null) {
+            selection.append(" and ")
+                    .append(NotificationData.COLUMN_NAME_BIG_TEXT)
+                    .append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_BIG_TEXT));
+        }
+        if (cv.getAsString(NotificationData.COLUMN_NAME_SUMMARY) != null) {
+            selection.append(" and ")
+                    .append(NotificationData.COLUMN_NAME_SUMMARY)
+                    .append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_SUMMARY));
+        }
+        if (cv.getAsString(NotificationData.COLUMN_NAME_TEXT_LINES) != null) {
+            selection.append(" and ")
+                    .append(NotificationData.COLUMN_NAME_TEXT_LINES)
+                    .append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_TEXT_LINES));
+        }
+        if (cv.getAsString(NotificationData.COLUMN_NAME_SUBTEXT) != null) {
+            selection.append(" and ")
+                    .append(NotificationData.COLUMN_NAME_SUBTEXT)
+                    .append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_SUBTEXT));
+        }
+        if (cv.getAsString(NotificationData.COLUMN_NAME_TICKER_TEXT) != null) {
+            selection.append(" and ")
+                    .append(NotificationData.COLUMN_NAME_TICKER_TEXT)
+                    .append("=?");
+            selectionArgs.add(cv.getAsString(NotificationData.COLUMN_NAME_TICKER_TEXT));
+        }
+        String [] selectionArgsArr = new String[selectionArgs.size()];
+        return new Pair<>(selection.toString(), selectionArgs.toArray(selectionArgsArr));
+    }
+
+    /** Initializes the SQLiteDatabase object if needed.<br>Do not call this on main thread as it
+     *  blocks on getting the Database if needed.
+     */
+    private Void perhapsInitDB() {
+        if (notificationDB == null || !notificationDB.isOpen()) {
+            try {
+                Logger.d(this, "perhapsInitDB, DB not open, starting thread");
+                return Executors.newSingleThreadExecutor().submit(new Callable<Void>() {
+                    /*We are using Callable and Future to return value from the thread. Calling
+                    thread blocks in get() till the result is available.*/
+                    @Override
+                    public Void call() {
+                        synchronized (instance) {
+                            notificationDB = notificationDBOpenHelper.getWritableDatabase();
+                        }
+                        return null;
+                    }
+                }).get();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            } catch (ExecutionException e) {
+                e.printStackTrace();
             }
         }
-        String [] selectionArgs = new String[] {Integer.toString(NOTIFICATION_READ)};
-        notificationDB.delete(NotificationData.TABLE_NAME, IS_UNREAD_SELECTION, selectionArgs);
+        return null;
     }
 
     /**Utility method to convert an array of Charsequences to a String*/
-    private String getString(CharSequence[] charSequences) {
+    private String charSequenceArrayToString(CharSequence[] charSequences) {
         if (charSequences == null || charSequences.length == 0) {
             return null;
         }
@@ -251,6 +415,10 @@ public class NotificationDBOps {
     private String dumpAllRowsToString() {
         Cursor cursor = notificationDB.query(NotificationData.TABLE_NAME,
                 null, null, null, null, null, null);
-        return DatabaseUtils.dumpCursorToString(cursor);
+        String toReturn = DatabaseUtils.dumpCursorToString(cursor);
+        if (cursor != null && !cursor.isClosed()) {
+            cursor.close();
+        }
+        return toReturn;
     }
 }

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/settings/SettingsFragment.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/settings/SettingsFragment.java
@@ -127,6 +127,7 @@ public class SettingsFragment extends PreferenceFragment implements
                         getString(R.string.pref_key_max_volume), true));
 
                 prefShakeDetection.setEnabled(true);
+                setShakeDetectionSummary();
             } else {
                 prefPersistentNotification.setEnabled(false);
                 prefApps.setEnabled(false);
@@ -154,6 +155,15 @@ public class SettingsFragment extends PreferenceFragment implements
                     prefApps.setSummary(getString(R.string.pref_apps_summary, appsList.size()));
                 }
             }
+        }
+    }
+
+    private void setShakeDetectionSummary() {
+        if (defaultSharedPreferences.getBoolean(
+                getString(R.string.pref_key_android_wear), false)) {
+            prefShakeDetection.setSummary(getString(R.string.pref_shake_detection_summary_on));
+        } else {
+            prefShakeDetection.setSummary(getString(R.string.pref_shake_detection_summary_off));
         }
     }
 
@@ -211,6 +221,8 @@ public class SettingsFragment extends PreferenceFragment implements
                 getString(R.string.pref_key_apps).equals(key)) {
             //Update summary text when apps selection data changes
             setPrefAppsSummary();
+        } else if (getString(R.string.pref_key_android_wear).equals(key)) {
+            setShakeDetectionSummary();
         }
     }
 }

--- a/JorSay/mobile/src/main/java/com/mocha17/slayer/tts/JorSayReader.java
+++ b/JorSay/mobile/src/main/java/com/mocha17/slayer/tts/JorSayReader.java
@@ -129,7 +129,7 @@ public class JorSayReader extends Service implements TextToSpeech.OnInitListener
                 if (ttsReady.get()) {
                     readAloud();
                 } else {
-                    readOnReady.compareAndSet(false, true);
+                    readOnReady.set(true);
                 }
             } else if (SNOOZE_READ_ALOUD == msg.what) {
                 if (tts != null) {

--- a/JorSay/mobile/src/main/res/values/strings.xml
+++ b/JorSay/mobile/src/main/res/values/strings.xml
@@ -71,6 +71,8 @@
 
     <string name="pref_key_shake_detection" translatable="false">pref_key_shake_detection</string>
     <string name="pref_shake_detection_title">Configure Shake Detection</string>
+    <string name="pref_shake_detection_summary_on">Shake Detection is on</string>
+    <string name="pref_shake_detection_summary_off">Shake Detection is off</string>
     <string name="pref_key_android_wear" translatable="false">pref_key_android_wear</string>
     <string name="pref_android_wear">Enable Shake Detection using Android Wear</string>
     <string name="pref_android_wear_summary_off">Will read notifications aloud immediately</string>

--- a/JorSay/wear/build.gradle
+++ b/JorSay/wear/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.mocha17.slayer"
         minSdkVersion 19
         targetSdkVersion 22
-        versionCode 9
-        versionName "1.5"
+        versionCode 11
+        versionName "1.7"
     }
     buildTypes {
         release {

--- a/JorSay/wear/src/main/AndroidManifest.xml
+++ b/JorSay/wear/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mocha17.slayer"
-    android:versionCode="9"
-    android:versionName="1.5.0" >
+    android:versionCode="11"
+    android:versionName="1.7" >
 
     <!-- KITKAT to LOLLIPOP_MR1 -->
     <uses-sdk


### PR DESCRIPTION
This commit contains some major changes to avoid reading identical notifications multiple times:
1. Apps could choose to post the same notification again - for example, a 'downloading file' notification from an app, with nothing to differentiate it - like current progress - from the earlier ones. JorSay won't read such notifications again and again.
Caveat: We remove 'read' notifications out-of-band, and thus could end up reading an identical notification again. However, the likelihood of this is low, as our out-of-band interval is 1 day which is large enough.
2. When a notification is removed, it is also deleted from the table we maintain. We could then read it again, if it is posted again.
3. This required significant under-the-hood changes to our DB and related code. The DB now stores a notification only if an identical notification is not already present in the table. It returns if it stored a notification successfully, and the notificationListener takes the next action on it only if it was stored in the table. When a notification is removed, it is removed from the table too. We dynamically generate the selection parameter and associated selectionArgs for both insert and delete operations - details are in the comments. Additionally, DB initialization is now done using ExecutorService, and NotificationListener now utilizes a HandlerThread to do all DB interaction off the main thread. This is important - we now have NOTHING involving DB happening on the main thread.(!)

Testing done:
Verified that
1. identical notifications are not read multiple times.
2. different notifications are indeed read.
3. if a notification is removed and posted again, it is read.
4. if multiple notifications are posted, they are read one after another.